### PR TITLE
Issue with phpdotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=7.0.0",
     "guzzlehttp/guzzle": "^6.2",
     "illuminate/support": "^5.4",
-    "vlucas/phpdotenv": "^2.4"
+    "vlucas/phpdotenv": "^3.3"
   },
   "require-dev": {
     "mockery/mockery": "0.9.*",


### PR DESCRIPTION
Noticed the the baremetrics-api was breaking some of my event listeners with an exception:

`In helpers.php line 646:`

```                                                                         
  [Symfony\Component\Debug\Exception\ClassNotFoundException]                    
  Attempted to load class "DotenvFactory" from namespace "Dotenv\Environment".  
  Did you forget a "use" statement for another namespace?
```

at `illuminate/support/helpers.php:646`

The package illuminate/support suggests version phpdotenv 3.3 as version 2 seems to break in the stack.

Updating vlucas/phpdotenv to 3.3 in composer fixes the issue.